### PR TITLE
Add read convenience methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StringEncodings"
 uuid = "69024149-9ee7-55f6-a4c4-859efe599b68"
-repo = "https://github.com/JuliaStrings/StringEncodings.jl.git"
+version = "0.3.2"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ noël
 
 julia> readuntil(path, enc"UTF-16", "ë")
 "café\nno"
+
+julia> String(read(path, enc"UTF-16"))
+"café\nnoël"
+
+julia> String(read(path, 5, enc"UTF-16"))
+"café"
 ```
 
 When performing more complex operations on an encoded text file, it will often be easier to specify the encoding only once when opening it. The resulting I/O stream can then be passed to functions that are unaware of encodings (i.e. that assume UTF-8 text):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.4
   - julia_version: nightly
 
 platform:

--- a/src/StringEncodings.jl
+++ b/src/StringEncodings.jl
@@ -279,7 +279,7 @@ stream does not close `stream`.
 
 `to` and `from` can be specified either as a string or as an `Encoding` object.
 
-Note that some implementations (notably the Windows one) may accept invalid sequences
+Note that some implementations may accept invalid sequences
 in the input data without raising an error.
 """
 function StringDecoder(stream::IO, from::Encoding, to::Encoding=enc"UTF-8")

--- a/src/StringEncodings.jl
+++ b/src/StringEncodings.jl
@@ -202,7 +202,7 @@ end
 
 Returns a new write-only I/O stream, which converts any text in the encoding `from`
 written to it into text in the encoding `to` written to `stream`. Calling `close` on the
-stream is necessary to complete the encoding (but does not close `stream`).
+returned object is necessary to complete the encoding (but it does not close `stream`).
 
 `to` and `from` can be specified either as a string or as an `Encoding` object.
 """
@@ -404,13 +404,26 @@ function open(fname::AbstractString, enc::Encoding, mode::AbstractString)
 end
 
 """
+    read(stream::IO, [nb::Integer,] enc::Encoding)
+    read(filename::AbstractString, [nb::Integer,] enc::Encoding)
     read(stream::IO, ::Type{String}, enc::Encoding)
     read(filename::AbstractString, ::Type{String}, enc::Encoding)
 
-Methods to read text in character encoding `enc`.
+Methods to read text in character encoding `enc`. See documentation for corresponding methods
+without the `enc` argument for details.
 """
-Base.read(s::IO, ::Type{String}, enc::Encoding) = read(StringDecoder(s, enc), String)
-Base.read(filename::AbstractString, ::Type{String}, enc::Encoding) = open(io->read(io, String, enc), filename)
+Base.read(s::IO, enc::Encoding) =
+    read(StringDecoder(s, enc))
+Base.read(filename::AbstractString, enc::Encoding) =
+    open(io->read(io, enc), filename)
+Base.read(s::IO, nb::Integer, enc::Encoding) =
+    read(StringDecoder(s, enc), nb)
+Base.read(filename::AbstractString, nb::Integer, enc::Encoding) =
+    open(io->read(io, nb, enc), filename)
+Base.read(s::IO, ::Type{String}, enc::Encoding) =
+    read(StringDecoder(s, enc), String)
+Base.read(filename::AbstractString, ::Type{String}, enc::Encoding) =
+    open(io->read(io, String, enc), filename)
 
 """
     readline(stream::IO, enc::Encoding; keep::Bool=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,18 @@ mktemp() do path, io
         write(io, s)
     end
 
+    @test String(read(path, enc"ISO-2022-JP")) == s
+    @test String(open(io->read(io, enc"ISO-2022-JP"), path)) == s
+    @test String(open(io->read(io), path, enc"ISO-2022-JP")) == s
+
+    @test String(read(path, 1000, enc"ISO-2022-JP")) == s
+    @test String(open(io->read(io, 1000, enc"ISO-2022-JP"), path)) == s
+    @test String(open(io->read(io, 1000), path, enc"ISO-2022-JP")) == s
+
+    @test String(read(path, 10, enc"ISO-2022-JP")) == first(s, 10)
+    @test String(open(io->read(io, 10, enc"ISO-2022-JP"), path)) == first(s, 10)
+    @test String(open(io->read(io, 10), path, enc"ISO-2022-JP")) == first(s, 10)
+
     @test read(path, String, enc"ISO-2022-JP") == s
     @test open(io->read(io, String, enc"ISO-2022-JP"), path) == s
     @test open(io->read(io, String), path, enc"ISO-2022-JP") == s


### PR DESCRIPTION
These methods differ a bit from existing ones since they don't return strings (for which the UTF-8 encoding is known thanks to their type), but bytes without any encoding information. But this shouldn't be too confusing, and it can be useful e.g. for CSV.jl which expects a vector of bytes in UTF-8 rather than a string.