### PR TITLE
Improve performance 

### DIFF
--- a/src/StringEncodings.jl
+++ b/src/StringEncodings.jl
@@ -410,7 +410,6 @@ end
 # as the buffer contains on each iteration rather than a single one,
 # which increases performance dramatically
 function readbytes!(s::StringDecoder, b::AbstractArray{UInt8}, nb=length(b))
-    Base.require_one_based_indexing(b)
     olb = lb = length(b)
     nr = 0
     i = 0
@@ -421,7 +420,7 @@ function readbytes!(s::StringDecoder, b::AbstractArray{UInt8}, nb=length(b))
             lb = (nr+nc) * 2
             resize!(b, lb)
         end
-        copyto!(b, nr+1, s.outbuf, s.skip+1, nc)
+        copyto!(b, firstindex(b)+nr, s.outbuf, s.skip+1, nc)
         s.skip += nc
         nr += nc
     end


### PR DESCRIPTION
Add optimized `readbytes!` method which copies data by chunks instead of byte per byte.
Internally, avoid passing a `SubArray` to `readbytes!` as there is currently no optimized method for them: instead, wrap the corresponding memory in an `Array`.
Increase the size of the buffer from 100 to 200 bytes, which appears to be a good tradeoff.
This makes loading a file about 10 times faster than before.

See also https://github.com/JuliaLang/julia/pull/36607.